### PR TITLE
Allow and handle larger sequence lengths for MUSE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,4 +180,4 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
 
-.vscode/settings.json
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,4 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
 
+.vscode/settings.json

--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,8 @@ check_dirs := scripts src tests #setup.py
 quality:
 	ruff check $(check_dirs)
 
+style:
+	ruff --format $(check_dirs)
+
 test:
 	CUDA_VISIBLE_DEVICES= pytest tests/

--- a/configs/data/datasets/MUSE_forget.yaml
+++ b/configs/data/datasets/MUSE_forget.yaml
@@ -3,8 +3,7 @@ MUSE_forget:
   args:
     hf_args:
       path: "muse-bench/MUSE-News"
-      name: "train"
+      name: "raw"
       split: "forget"
     text_key: "text"
-    max_length: 128
-    insert_space: True
+    max_length: 2048

--- a/configs/data/datasets/MUSE_forget_privleak.yaml
+++ b/configs/data/datasets/MUSE_forget_privleak.yaml
@@ -1,5 +1,5 @@
 MUSE_forget_privleak:
-  handler: PretrainingDataset
+  handler: CompletionDataset
   args:
     hf_args:
       path: "muse-bench/MUSE-News"
@@ -7,3 +7,4 @@ MUSE_forget_privleak:
       split: "forget"
     prefix_key: "prompt" # doesn't exist in dataset
     text_key: "text"
+    max_length: 2048

--- a/configs/data/datasets/MUSE_forget_scal.yaml
+++ b/configs/data/datasets/MUSE_forget_scal.yaml
@@ -6,5 +6,4 @@ MUSE_forget_scal:
       name: "scal"
       split: "forget_4"
     text_key: "text"
-    max_length: 128
-    insert_space: True
+    max_length: 2048

--- a/configs/data/datasets/MUSE_forget_sust.yaml
+++ b/configs/data/datasets/MUSE_forget_sust.yaml
@@ -6,5 +6,4 @@ MUSE_forget_sust:
       name: "sust"
       split: "forget_1"
     text_key: "text"
-    max_length: 128
-    insert_space: True
+    max_length: 2048

--- a/configs/data/datasets/MUSE_forget_verbmem.yaml
+++ b/configs/data/datasets/MUSE_forget_verbmem.yaml
@@ -1,5 +1,5 @@
 MUSE_forget_verbmem:
-  handler: PretrainingDataset
+  handler: CompletionDataset
   args:
     hf_args:
       path: "muse-bench/MUSE-News"
@@ -7,5 +7,5 @@ MUSE_forget_verbmem:
       split: "forget"
     prefix_key: "prompt"
     text_key: "gt"
-    max_length: 128
+    max_length: 2048
     insert_space: True

--- a/configs/data/datasets/MUSE_holdout_privleak.yaml
+++ b/configs/data/datasets/MUSE_holdout_privleak.yaml
@@ -1,5 +1,5 @@
 MUSE_holdout_privleak:
-  handler: PretrainingDataset
+  handler: CompletionDataset
   args:
     hf_args:
       path: "muse-bench/MUSE-News"
@@ -7,3 +7,4 @@ MUSE_holdout_privleak:
       split: "holdout"
     prefix_key: "prompt" # doesn't exist in dataset
     text_key: "text"
+    max_length: 2048

--- a/configs/data/datasets/MUSE_retain.yaml
+++ b/configs/data/datasets/MUSE_retain.yaml
@@ -3,8 +3,7 @@ MUSE_retain:
   args:
     hf_args:
       path: "muse-bench/MUSE-News"
-      name: "train"
+      name: "raw"
       split: "retain1"
     text_key: "text"
-    max_length: 128
-    insert_space: True
+    max_length: 2048

--- a/configs/data/datasets/MUSE_retain_privleak.yaml
+++ b/configs/data/datasets/MUSE_retain_privleak.yaml
@@ -5,5 +5,5 @@ MUSE_retain_privleak:
       path: "muse-bench/MUSE-News"
       name: "privleak"
       split: "retain"
-    prefix_key: "prompt" # doesn't exist in dataset
     text_key: "text"
+    max_length: 2048

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -9,7 +9,7 @@ from data.collators import (
     DataCollatorForSupervisedDataset,
 )
 from data.unlearn import ForgetRetainDataset
-from data.pretraining import PretrainingDataset
+from data.pretraining import PretrainingDataset, CompletionDataset
 
 DATASET_REGISTRY: Dict[str, Any] = {}
 COLLATOR_REGISTRY: Dict[str, Any] = {}
@@ -98,6 +98,7 @@ def get_collators(collator_cfgs, **kwargs):
 _register_data(QADataset)
 _register_data(QAwithIdkDataset)
 _register_data(PretrainingDataset)
+_register_data(CompletionDataset)
 
 # Register composite datasets used in unlearning
 # groups: unlearn

--- a/src/data/pretraining.py
+++ b/src/data/pretraining.py
@@ -59,7 +59,7 @@ class CompletionDataset(Dataset):
         return item
 
 
-class PretrainingDataset(CompletionDataset):
+class PretrainingDataset(Dataset):
     def __init__(
         self, hf_args, template_args, tokenizer, text_key="text", max_length=2048
     ):
@@ -84,8 +84,9 @@ class PretrainingDataset(CompletionDataset):
         return chunks
 
     def __len__(self):
-        return len(self.data)
+        return len(self.chunks)
 
     def __getitem__(self, idx):
-        item = self._process_sample("", self.chunks[idx])
-        return item
+        return preprocess_pretraining_instance(
+            self.tokenizer, "", self.chunks[idx], self.max_length
+        )

--- a/src/data/pretraining.py
+++ b/src/data/pretraining.py
@@ -7,7 +7,7 @@ from data.utils import (
 )
 
 
-class PretrainingDataset(Dataset):
+class CompletionDataset(Dataset):
     def __init__(
         self,
         hf_args,
@@ -15,11 +15,11 @@ class PretrainingDataset(Dataset):
         tokenizer,
         prefix_key="prompt",
         text_key="text",
-        max_length=128,
+        max_length=2048,
         predict_with_generate=False,
         insert_space=False,
     ):
-        super(PretrainingDataset, self).__init__()
+        super(CompletionDataset, self).__init__()
         self.tokenizer = tokenizer
         self.max_length = max_length
         self.data = load_hf_dataset(**hf_args)
@@ -46,8 +46,9 @@ class PretrainingDataset(Dataset):
             "input_ids": tokenized_data["input_ids"],
             "labels": tokenized_data["labels"],
             "attention_mask": tokenized_data["attention_mask"],
-            "index": index,
         }
+        if index != -1:
+            item_dct["index"] = index
         return item_dct
 
     def __getitem__(self, idx):
@@ -55,4 +56,36 @@ class PretrainingDataset(Dataset):
         text_content = self.data[idx].get(self.text_key, "")
         index = self.data[idx]["index"]
         item = self._process_sample(pref, text_content, index)
+        return item
+
+
+class PretrainingDataset(CompletionDataset):
+    def __init__(
+        self, hf_args, template_args, tokenizer, text_key="text", max_length=2048
+    ):
+        super(PretrainingDataset, self).__init__()
+        self.tokenizer = tokenizer
+        self.max_length = max_length
+        self.chunks = self._chunk_raw_text(load_hf_dataset(**hf_args)[text_key])
+
+    def _chunk_raw_text(self, raw_text):
+        raw_text = "\n\n".join(raw_text)
+        full_token_sequence = self.tokenizer(raw_text, add_special_tokens=False)[
+            "input_ids"
+        ]
+        num_chunks = len(full_token_sequence) // self.max_length + 1
+        chunks = []
+        for i in range(num_chunks):
+            chunks.append(
+                self.tokenizer.decode(
+                    full_token_sequence[i * self.max_length : (i + 1) * self.max_length]
+                )
+            )
+        return chunks
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, idx):
+        item = self._process_sample("", self.chunks[idx])
         return item


### PR DESCRIPTION
1. Increase MUSE pretraining dataset max len from 128 to 2048 (fix)
2. Separate out pretraining dataset and completion dataset
3. Pretraining dataset chunks raw texts
4. Fixes to MUSE configs to not use spaces after prompt, use raw split instead of train split